### PR TITLE
Hotkey snapshots

### DIFF
--- a/src/minarch/minarch.c
+++ b/src/minarch/minarch.c
@@ -520,6 +520,8 @@ static void downsample(void* __restrict src, void* __restrict dst, uint32_t w, u
 
 static void State_write(void) { // from picoarch
 	char bmp_path[256];
+	char slot_path[256];
+	char txt_path[256];
 	char minui_dir[256];
 	char emu_name[256];
 	SDL_Surface* backing = GFX_getBufferCopy();
@@ -561,11 +563,21 @@ static void State_write(void) { // from picoarch
 
 	getEmuName(game.path, emu_name);
 	sprintf(minui_dir, USERDATA_PATH "/.minui/%s", emu_name);
+	sprintf(slot_path, "%s/%s.txt", minui_dir, game.name);
   sprintf(bmp_path, "%s/%s.%d.bmp", minui_dir, game.name, state_slot);
   SDL_Surface* preview = Menu_thumbnail(snapshot);
   SDL_RWops* out = SDL_RWFromFile(bmp_path, "wb");
+
+  if (exists(game.m3u_path)) {
+    char* tmp = strrchr(game.m3u_path, '/') + 1;
+    sprintf(txt_path, "%s/%s.%d.txt", minui_dir, tmp, state_slot);
+    tmp = strrchr(game.path, '/') + 1;
+    putFile(txt_path, tmp);
+  }
+
   SDL_SaveBMP_RW(preview, out, 1);
   SDL_FreeSurface(preview);
+  putInt(slot_path, state_slot);
 
 error:
 	if (state) free(state);

--- a/src/minarch/minarch.c
+++ b/src/minarch/minarch.c
@@ -23,6 +23,43 @@
 
 ///////////////////////////////////////
 
+#define MENU_ITEM_COUNT 5
+#define MENU_SLOT_COUNT 8
+
+enum {
+	ITEM_CONT,
+	ITEM_SAVE,
+	ITEM_LOAD,
+	ITEM_OPTS,
+	ITEM_QUIT,
+};
+
+enum {
+	STATUS_CONT =  0,
+	STATUS_SAVE =  1,
+	STATUS_LOAD = 11,
+	STATUS_OPTS = 23,
+	STATUS_DISC = 24,
+	STATUS_QUIT = 30
+};
+
+static struct {
+	int initialized;
+	SDL_Surface* overlay;
+	char* items[MENU_ITEM_COUNT];
+	int slot;
+} menu = {
+	.items = {
+		[ITEM_CONT] = "Continue",
+		[ITEM_SAVE] = "Save",
+		[ITEM_LOAD] = "Load",
+		[ITEM_OPTS] = "Options",
+		[ITEM_QUIT] = "Quit",
+	}
+};
+
+///////////////////////////////////////
+
 static SDL_Surface* screen;
 static int quit;
 static int show_menu;
@@ -577,6 +614,8 @@ static void State_write(void) { // from picoarch
 
   SDL_SaveBMP_RW(preview, out, 1);
   SDL_FreeSurface(preview);
+  SDL_FreeSurface(backing);
+  SDL_FreeSurface(snapshot);
   putInt(slot_path, state_slot);
 
 error:
@@ -3027,42 +3066,6 @@ void Core_close(void) {
 	if (core.handle) dlclose(core.handle);
 }
 
-///////////////////////////////////////
-
-#define MENU_ITEM_COUNT 5
-#define MENU_SLOT_COUNT 8
-
-enum {
-	ITEM_CONT,
-	ITEM_SAVE,
-	ITEM_LOAD,
-	ITEM_OPTS,
-	ITEM_QUIT,
-};
-
-enum {
-	STATUS_CONT =  0,
-	STATUS_SAVE =  1,
-	STATUS_LOAD = 11,
-	STATUS_OPTS = 23,
-	STATUS_DISC = 24,
-	STATUS_QUIT = 30
-};
-
-static struct {
-	int initialized;
-	SDL_Surface* overlay;
-	char* items[MENU_ITEM_COUNT];
-	int slot;
-} menu = {
-	.items = {
-		[ITEM_CONT] = "Continue",
-		[ITEM_SAVE] = "Save",
-		[ITEM_LOAD] = "Load",
-		[ITEM_OPTS] = "Options",
-		[ITEM_QUIT] = "Quit",
-	}
-};
 
 
 void Menu_init(void) {
@@ -4040,14 +4043,8 @@ static void Menu_loop(void) {
 					status = STATUS_SAVE;
 					SDL_Surface* preview = Menu_thumbnail(snapshot);
 					SDL_RWops* out = SDL_RWFromFile(bmp_path, "wb");
-					if (total_discs) {
-						char* disc_path = disc_paths[disc];
-						putFile(txt_path, disc_path + strlen(base_path));
-						sprintf(bmp_path, "%s/%s.%d.bmp", minui_dir, game.name, menu.slot);
-					}
 					SDL_SaveBMP_RW(preview, out, 1);
 					SDL_FreeSurface(preview);
-					putInt(slot_path, menu.slot);
 					show_menu = 0;
 				}
 				break;


### PR DESCRIPTION
I noticed the hotkey save state didn't create a snapshot for the save states so I tweaked the State_write to save a snapshot.

I'm not 100% satisfied with this - the hotkeys vs menu save states seem to be treated quite differently in ways I don't totally understand (I'm pretty sure the hotkeys don't save disk information (txt_path) along with other differences). Due to this, I did not remove the menu item save state's txt_path and snapshot stuff. As a result, the snapshot is being created twice in this situation.

I'm also not crazy about the fact that hotkeys seem to always save to either save state 0 or to whatever was last interacted with in the menu. This behavior seems a little weird but I'm not sure what to do about it.