### PR TITLE
load the core before loading the state

### DIFF
--- a/src/minarch/minarch.c
+++ b/src/minarch/minarch.c
@@ -4341,16 +4341,18 @@ int main(int argc , char* argv[]) {
 	
 	Menu_init();
 	
-	State_resume();
-	
 	POW_warn(1);
 	POW_disableAutosleep();
 	sec_start = SDL_GetTicks();
+  core.run();
+  State_resume();
+
 	while (!quit) {
 		GFX_startFrame();
 		
 		core.run();
 		limitFF();
+
 		
 		if (show_menu) Menu_loop();
 		


### PR DESCRIPTION
Some PS games had weird graphical glitches - moving State_resume after core.run seems to have resolved it - but I'm not 100% sure if it is reasonable...